### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/mochawesome.js
+++ b/lib/mochawesome.js
@@ -1,7 +1,7 @@
 /*jshint loopfunc: true */
 var mocha     = require('mocha'),
     _         = require('lodash'),
-    uuid      = require('node-uuid'),
+    uuid      = require('uuid'),
     chalk     = require('chalk'),
     Highlight = require('highlight.js'),
     reportGen = require('./reportGenerator'),

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
   "dependencies": {
     "async": "^0.9.0",
     "chalk": "^1.0.0",
+    "debug": "^2.2.0",
+    "diff": "^1.4.0",
+    "glob": "^7.0.3",
     "handlebars": "^3.0.3",
     "highlight.js": "^8.5.0",
     "json-stringify-safe": "^5.0.0",
@@ -32,12 +35,9 @@
     "mkdirp": "^0.5.1",
     "moment": "^2.9.0",
     "ncp": "^1.0.1",
-    "node-uuid": "^1.4.1",
     "opener": "^1.4.1",
-    "diff": "^1.4.0",
-    "debug": "^2.2.0",
-    "glob": "^7.0.3",
-    "util": "^0.10.3"
+    "util": "^0.10.3",
+    "uuid": "^3.0.0"
   },
   "peerDependencies": {
     "mocha": "*"


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.