### PR TITLE
Support added for Puppeteer framework.

### DIFF
--- a/lib/reportGenerator.js
+++ b/lib/reportGenerator.js
@@ -99,16 +99,25 @@ function clearScreenshots (config) {
 }
 
 function saveScreenshotToFile (outFile) {
-    if (typeof browser === 'undefined') {
+    if (typeof page === 'undefined') {
         return;
     }
     try {
         var file = path.resolve(outFile);
-        browser.takeScreenshot().then(function (png) {
-            fs.writeFileSync(file, png, { encoding: 'base64' });
+        try {
+        	// take screen shot for Protector
+           browser.takeScreenshot().then(function (png) {
+        fs.writeFileSync(file, png, { encoding: 'base64' });
         }, function(err){
-            console.log('\n[' + chalk.gray('mochawesome') + '] Error: Unable to save screenshot - ' + outFile + '\n' + err + '\n');
-        });
+        console.log('\n[' + chalk.gray('mochawesome') + '] Error: Unable to save screenshot - ' + outFile + '\n' + err + '\n');});
+        } catch (error) {
+          try {
+        	// take screen shot for Puppeteer
+            page.screenshot({ path: file });
+          } catch (error) {
+            console.log('\n[' + chalk.gray('mochawesome') + '] Error: Unable to save screenshot - ' + outFile + '\n' + error + '\n');
+          }
+        }
     } catch (err) {
         console.log('\n[' + chalk.gray('mochawesome') + '] Error: Unable to save screenshot - ' + outFile + '\n' + err + '\n');
     }


### PR DESCRIPTION
After this change user can also use same report for Puppeteer framework.
For Puppeteer framework, While writing test script page should be define
as global just like defining browser as global in Protector.